### PR TITLE
Changes tstl config to nanos world compatible configurations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
         "strict": true
     },
     "tstl": {
-        "luaTarget": "JIT"
+        "luaTarget": "universal",
+        "luaLibImport": "inline"
     },
     "include":[
         "src/**/*"


### PR DESCRIPTION
I changed a few compiler options in the template, namely:

- luaTarget: NanosWorld does not seem to support LuaJit, I reverted the configuration to universal
- luaLibImport: I made it to inline, despite it might make code chunks bigger, it avoids tstl to use `require` (wich nanos world interprets as a dll import), a better option might be to default to `Package.Require` but I have not found a way to it yet